### PR TITLE
Update pyyaml usage

### DIFF
--- a/curator/utils.py
+++ b/curator/utils.py
@@ -50,7 +50,7 @@ def get_yaml(path):
     yaml.add_constructor('!single', single_constructor)
 
     try:
-        return yaml.load(read_file(path))
+        return yaml.load(read_file(path), Loader=yaml.FullLoader)
     except yaml.scanner.ScannerError as err:
         print('Unable to read/parse YAML file: {0}'.format(path))
         print(err)


### PR DESCRIPTION
Updating pyyaml usage to be compliant with v6.0.1 so that we can install it on apple silicon

original implementation uses `FullLoader` loader: https://github.com/untergeek/es_client/blob/master/es_client/helpers/utils.py#L145